### PR TITLE
[CF-791] Preference service - container name validation

### DIFF
--- a/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
+++ b/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
@@ -210,7 +210,7 @@ with JacksonJsonSupport {
                 //Removing any hex-characters from original.
                 //Encoding the resultant string should not change it. If it changes, it indicates there are still special chars.
 
-                val hexStrippedContainerName = containerName.replaceAll("%[0-9][0-9]", "")
+                val hexStrippedContainerName = containerName.replaceAll("%[A-Z0-9][A-Z0-9]", "")
                 val encodedHexStrippedContainerName = UriUtils.encodePathSegment(hexStrippedContainerName, "UTF-8")
 
                 if (hexStrippedContainerName != encodedHexStrippedContainerName) {

--- a/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
+++ b/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
@@ -137,6 +137,21 @@ with JacksonJsonSupport {
         result
     }
 
+  /**
+   * Cloud files has the following requirements for container name. This method validates to make sure the container name is compatible 
+   * with cloud files. 
+   * 
+   * The only restrictions on container names is that they cannot contain a forward slash (/) and must be less than 256 bytes in length. 
+   * Note that the length restriction applies to the name after it has been URL-encoded. For example, a container name of Course Docs 
+   * would be URL-encoded as Course%20Docs and is therefore 13 bytes in length rather than the expected 11.
+   * 
+   * http://docs.rackspace.com/files/api/v1/cf-devguide/content/Containers-d1e458.html
+   *
+   * @param preferenceSlug
+   * @param id
+   * @param containerUrl
+   * @return
+   */
     def validateContainerName(preferenceSlug: String, id: String, containerUrl: String): ActionResult = {
         // validate container name
         var result:ActionResult = null
@@ -155,33 +170,68 @@ with JacksonJsonSupport {
             result = BadRequest(jsonifyError("Preferences for /" + preferenceSlug + "/" + id + " is missing container name: " + containerUrl))
         }
         else {
+
+          if (containerName.length() >= 256) {
+            logger.debug(s"Encoded container name should be less than 256 bytes in length:[$containerUrl]")
+            
+            result = BadRequest(jsonifyError("Preferences for /" + preferenceSlug + "/" + id + " has an encoded container name longer than 255 bytes: " + containerUrl +
+              "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length."))
+            
+          } else {
+
             // container name must be less than 256 bytes in length, url encoded, and does not contain '/'
             val msgInvalidUrl =
-                "Preferences for /" + preferenceSlug + "/" + id + " has an invalid url: " + containerUrl +
-                "\nUrl must be encoded and should not contain query parameters or url fragments."
+              "Preferences for /" + preferenceSlug + "/" + id + " has an invalid url: " + containerUrl +
+                "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length."
 
             try {
-                // first decode the containerName
-                val decoded = UriUtils.decode(containerName, "UTF-8")
 
-                // then re-encode the decoded containerName
-                val reEncoded = UriUtils.encodePathSegment(decoded, "UTF-8")
+              // check to see if container has special chars and url encoded
+              // first decode the containerName
+              val decoded = UriUtils.decode(containerName, "UTF-8")
+
+              //If decoding results with the same container name, either it hasnt been encoded or encoding doesnt actually change anything (Ex: a alpha-numeric string like "Tom")
+              if (containerName == decoded) {
+
+                //To make sure whether encoding changes anything
+                val encode = UriUtils.encodePathSegment(containerName, "UTF-8")
+                
+                // if encoding the container name isn't same as the original, then container has special chars that are not encoded, bad request
+                if (encode != containerName) {
+                  logger.debug(s"Encoding the container name isn't same as the original:[$containerUrl]")
+                  result = BadRequest(jsonifyError(msgInvalidUrl))
+                }
+                
+              } else {
+                //Since decoded container name is not same as the original, we can think container name is probably already encoded.
+                //But they could have send mixed case where only part of the container name is encoded. So decoding results in a different container
+                //name but that doesnt mean the entire container name is properly encoded.
+
+                //Removing any hex-characters from original.
+                //Encoding the resultant string should not change it. If it changes, it indicates there are still special chars.
+
+                val hexStrippedContainerName = containerName.replaceAll("%[0-9][0-9]", "")
+                val encodedHexStrippedContainerName = UriUtils.encodePathSegment(hexStrippedContainerName, "UTF-8")
+
+                if (hexStrippedContainerName != encodedHexStrippedContainerName) {
+                  logger.debug(s"mixed case(partially encoded) container name:[$containerUrl]")
+                  // if encoding the container name isn't the same as the original, then container has special chars that are not encoded, bad request
+                  result = BadRequest(jsonifyError(msgInvalidUrl))
+                }
 
                 if (decoded contains '/') {
-                    // containerName contain '/', bad request
-                    result = BadRequest(jsonifyError("Preferences for /" + preferenceSlug + "/" + id + " has an invalid container name containing '/': " + containerUrl))
+                  logger.debug(s"Container name contains forward slash(/) which is invalid:[$containerUrl]")
+                  // containerName contains '/', bad request
+                  result = BadRequest(jsonifyError("Preferences for /" + preferenceSlug + "/" + id + " has an invalid container name containing '/': " + containerUrl +
+                    "\nUrl must be encoded and should not contain query parameters or url fragments."))
                 }
-                else if (reEncoded.length() >= 256) {
-                    // length of encoded containerName is greater than 255 bytes, bad request
-                    result = BadRequest(jsonifyError("Preferences for /" + preferenceSlug + "/" + id + " has an encoded container name longer than 255 bytes: " + containerUrl))
-                }
-                else if (reEncoded != containerName) {
-                    result = BadRequest(jsonifyError(msgInvalidUrl))
-                }
+              }
             }
             catch {
-                case e: Exception => result = BadRequest(jsonifyError(msgInvalidUrl + "\nError: " + e))
+              case e: Exception => result = BadRequest(jsonifyError(msgInvalidUrl + "\nError: " + e))
             }
+          }
+
         }
         result
     }

--- a/app/src/test/resources/c3p0-config.xml
+++ b/app/src/test/resources/c3p0-config.xml
@@ -2,7 +2,7 @@
 <c3p0-config>
     <default-config>
         <property name="driverClass">org.h2.Driver</property>
-        <property name="jdbcUrl">jdbc:h2:file:./build/db/test/preferencesdb;MODE=PostgreSQL;IGNORECASE=TRUE</property>
+        <property name="jdbcUrl">jdbc:h2:file:./app/build/db/test/preferencesdb;MODE=PostgreSQL;IGNORECASE=TRUE</property>
         <property name="user">root</property>
         <property name="password"></property>
         <property name="minPoolSize">1</property>

--- a/app/src/test/resources/logback.xml
+++ b/app/src/test/resources/logback.xml
@@ -1,0 +1,39 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- See also http://logback.qos.ch/manual/appenders.html#RollingFileAppender -->
+    <appender name="defaultFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <File>preferences-service/preferences-service.log</File>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4r [%t] %-5p %c - %m%n</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- Keep 30 days of compressed history. -->
+            <maxHistory>30</maxHistory>
+
+            <!-- Daily rollover with gzip compression. -->
+            <FileNamePattern>preferences-service/preferences-service.%d{yyyy-MM-dd}.log.gz</FileNamePattern>
+        </rollingPolicy>
+    </appender>
+
+    <!--c3p0 logging-->
+    <logger name="com.mchange" level="INFO" /> 
+    
+    <!--jetting logging-->
+    <logger name="org.eclipse.jetty" level="INFO" />
+    
+    <root level="INFO">
+        <appender-ref ref="defaultFile" />
+        <!-- Uncomment this if you want to debug anything during development
+        <appender-ref ref="STDOUT" />
+        -->
+    </root>
+</configuration>

--- a/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
+++ b/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
@@ -88,7 +88,7 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
       |}
     """.stripMargin
 
-    val encodedUrl = """http://storage.stg.swift.racklabs.com/v1/Nast-Id_1/Feeds%20~!@$*()-+=_;,.Archive"""
+    val encodedUrl = """http://storage.stg.swift.racklabs.com/v1/Nast-Id_1/Feeds%20%21%40%23%2D%3D%5F~!@$*()-+=_;,.Archive"""
     val prefs_enable_all_encoded =
     f"""
       |{
@@ -602,7 +602,7 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
         val randomId = Random.nextInt()
         info("Calling POST /archive/" + randomId)
 
-        val invalidUrl = "http://storage.stg.swift.racklabs.com/v1/Nast-Id_1/Feeds/Archive"
+        val invalidUrl = "http://storage.stg.swift.racklabs.com/v1/Nast-Id_1/Feeds#Archive"
         post("/archive/" + randomId,
             f"""
               |{

--- a/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
+++ b/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
@@ -566,7 +566,7 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
                 """.stripMargin
                 , Map("Content-Type" -> "application/json")) {
                 status should equal (400)
-                body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments.")
+                body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length.")
             }
         }
 
@@ -592,10 +592,11 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
                 """.stripMargin
                 , Map("Content-Type" -> "application/json")) {
                 status should equal (400)
-                body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments.")
+                body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length.")
             }
         }
     }
+
 
     test("should get 400: POST of preferences with INVALID DEFAULT container name (with literal '/') to /archive/:id") {
         val randomId = Random.nextInt()
@@ -612,7 +613,7 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
             """.stripMargin
             , Map("Content-Type" -> "application/json")) {
             status should equal (400)
-            body should include ("Preferences for /archive/" + randomId + " has an invalid container name containing '/': " + invalidUrl)
+            body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length.")
         }
     }
 
@@ -677,7 +678,7 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
             """.stripMargin
             , Map("Content-Type" -> "application/json")) {
             status should equal (400)
-            body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments.")
+            body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length.")
         }
     }
 
@@ -703,7 +704,7 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
             """.stripMargin
             , Map("Content-Type" -> "application/json")) {
             status should equal (400)
-            body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments.")
+            body should include ("Preferences for /archive/" + randomId + " has an invalid url: " + invalidUrl + "\nUrl must be encoded and should not contain query parameters or url fragments. Encoded container name cannot contain a forward slash(/) and must be less than 256 bytes in length.")
         }
     }
 


### PR DESCRIPTION
- Identified that decoding and encoding a string(path segment) doesnt necessarily be same as original
- Changes to handle mixed case (partially encoded) container names
- Changes to error message
- Added test logback file
